### PR TITLE
feat: flow arg introspection, runtime args, and subcommand CLI

### DIFF
--- a/go-webminion/cmd/webminion/main.go
+++ b/go-webminion/cmd/webminion/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	webminion "github.com/stevendaniels/web_minion/go-webminion"
@@ -20,80 +22,181 @@ func main() {
 }
 
 func run(args []string) error {
-	fs := flag.NewFlagSet("webminion", flag.ContinueOnError)
+	if len(args) == 0 {
+		printUsage()
+		return fmt.Errorf("subcommand required")
+	}
 
-	command := fs.String("command", "", "Command to run: run | validate")
+	sub := args[0]
+	rest := args[1:]
+
+	switch sub {
+	case "run":
+		return cmdRun(rest)
+	case "validate":
+		return cmdValidate(rest)
+	case "help":
+		return cmdHelp(rest)
+	default:
+		printUsage()
+		return fmt.Errorf("unknown subcommand %q (valid: run, validate, help)", sub)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, "Usage:")
+	fmt.Fprintln(os.Stderr, "  wm run      --config=<path> [--arg key=val]... [--env-file=<path>]")
+	fmt.Fprintln(os.Stderr, "  wm validate --config=<path>")
+	fmt.Fprintln(os.Stderr, "  wm help     --config=<path>")
+}
+
+// argMap is a repeatable --arg flag collector.
+type argMap map[string]string
+
+func (a argMap) String() string { return fmt.Sprintf("%v", map[string]string(a)) }
+func (a argMap) Set(s string) error {
+	k, v, ok := strings.Cut(s, "=")
+	if !ok {
+		return fmt.Errorf("--arg must be key=value, got %q", s)
+	}
+	a[k] = v
+	return nil
+}
+
+func cmdRun(args []string) error {
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	configPath := fs.String("config", "", "Path to config file (YAML or JSON)")
 	headless := fs.Bool("headless", true, "Run Chrome in headless mode")
-	driverName := fs.String("driver", "chrome", "Driver to use: chrome | http")
+	driverName := fs.String("driver", "chrome", "Driver: chrome | http")
 	vaultType := fs.String("vault", "env", "Credential vault: env | keyring")
-	startDateStr := fs.String("start-date", "", "Start date for date range (YYYY-MM-DD)")
-	endDateStr := fs.String("end-date", "", "End date for date range (YYYY-MM-DD)")
+	startDateStr := fs.String("start-date", "", "Start date (YYYY-MM-DD)")
+	endDateStr := fs.String("end-date", "", "End date (YYYY-MM-DD)")
+	envFile := fs.String("env-file", "", "Path to .env file with KEY=VALUE pairs")
+
+	runtimeArgs := make(argMap)
+	fs.Var(runtimeArgs, "arg", "Runtime arg as key=value (repeatable)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-
-	switch *command {
-	case "run":
-		return cmdRun(*configPath, *driverName, *vaultType, *headless, *startDateStr, *endDateStr)
-	case "validate":
-		return cmdValidate(*configPath)
-	case "":
-		fs.Usage()
-		return fmt.Errorf("--command is required")
-	default:
-		return fmt.Errorf("unknown command: %q (valid: run, validate)", *command)
-	}
-}
-
-func cmdRun(configPath, driverName, vaultType string, headless bool, startDateStr, endDateStr string) error {
-	if configPath == "" {
+	if *configPath == "" {
 		return fmt.Errorf("--config is required")
 	}
 
-	flow, err := webminion.NewFlow(configPath)
+	flow, err := webminion.NewFlow(*configPath)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
 
-	if startDateStr != "" || endDateStr != "" {
-		start, end, err := parseDateRange(startDateStr, endDateStr)
+	if *startDateStr != "" || *endDateStr != "" {
+		start, end, err := parseDateRange(*startDateStr, *endDateStr)
 		if err != nil {
 			return err
 		}
 		flow = flow.WithDateRange(start, end)
 	}
 
+	merged := make(map[string]string)
+	if *envFile != "" {
+		pairs, err := parseEnvFile(*envFile)
+		if err != nil {
+			return err
+		}
+		for k, v := range pairs {
+			merged[k] = v
+		}
+	}
+	for k, v := range runtimeArgs {
+		merged[k] = v
+	}
+	if len(merged) > 0 {
+		flow = flow.WithArgs(merged)
+	}
+
 	var v vault.Vault
-	switch vaultType {
+	switch *vaultType {
 	case "keyring":
 		v = vault.NewKeyringVault()
 	default:
 		v = vault.NewEnvVault()
 	}
 
-	switch driverName {
+	switch *driverName {
 	case "http":
 		d := httpdv.New()
 		defer d.Close()
 		return flow.Run(d, v)
 	default:
-		d := chromedv.New(headless)
+		d := chromedv.New(*headless)
 		defer d.Close()
 		return flow.Run(d, v)
 	}
 }
 
-func cmdValidate(configPath string) error {
-	if configPath == "" {
+func cmdValidate(args []string) error {
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to config file (YAML or JSON)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" {
 		return fmt.Errorf("--config is required")
 	}
-	if _, err := webminion.NewFlow(configPath); err != nil {
+	if _, err := webminion.NewFlow(*configPath); err != nil {
 		return err
 	}
 	fmt.Println("config is valid")
 	return nil
+}
+
+func cmdHelp(args []string) error {
+	fs := flag.NewFlagSet("help", flag.ContinueOnError)
+	configPath := fs.String("config", "", "Path to config file (YAML or JSON)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *configPath == "" {
+		return fmt.Errorf("--config is required")
+	}
+
+	flow, err := webminion.NewFlow(*configPath)
+	if err != nil {
+		return fmt.Errorf("loading config: %w", err)
+	}
+
+	required := flow.RequiredArgs()
+	if len(required) == 0 {
+		fmt.Println("No required args.")
+		return nil
+	}
+	fmt.Println("Required args:")
+	for _, name := range required {
+		fmt.Printf("  %s\n", name)
+	}
+	return nil
+}
+
+func parseEnvFile(path string) (map[string]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening env file: %w", err)
+	}
+	defer f.Close()
+
+	result := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("env file line %q is not KEY=VALUE", line)
+		}
+		result[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	return result, scanner.Err()
 }
 
 func parseDateRange(startStr, endStr string) (time.Time, time.Time, error) {

--- a/go-webminion/cmd/webminion/main_test.go
+++ b/go-webminion/cmd/webminion/main_test.go
@@ -16,8 +16,7 @@ func writeConfig(t *testing.T, content string) string {
 	return p
 }
 
-func TestCommandValidate(t *testing.T) {
-	p := writeConfig(t, `id: test
+const validFlowYAML = `id: test
 flow:
   actions:
     - key: start
@@ -27,9 +26,11 @@ flow:
           value: https://example.com
         - method: body_includes
           is_validator: true
-`)
-	err := run([]string{"--command", "validate", "--config", p})
-	if err != nil {
+`
+
+func TestCommandValidate(t *testing.T) {
+	p := writeConfig(t, validFlowYAML)
+	if err := run([]string{"validate", "--config", p}); err != nil {
 		t.Fatalf("validate error: %v", err)
 	}
 }
@@ -39,21 +40,56 @@ func TestCommandValidate_BadConfig(t *testing.T) {
 flow:
   actions: []
 `)
-	err := run([]string{"--command", "validate", "--config", p})
-	if err == nil {
+	if err := run([]string{"validate", "--config", p}); err == nil {
 		t.Error("expected error for invalid config (no starting action), got nil")
 	}
 }
 
 func TestCommandUnknown(t *testing.T) {
-	if err := run([]string{"--command", "foobar"}); err == nil {
-		t.Error("expected error for unknown command, got nil")
+	if err := run([]string{"foobar"}); err == nil {
+		t.Error("expected error for unknown subcommand, got nil")
 	}
 }
 
-func TestCommandMissingCommand(t *testing.T) {
+func TestCommandMissingSubcommand(t *testing.T) {
 	if err := run([]string{}); err == nil {
-		t.Error("expected error when --command is missing, got nil")
+		t.Error("expected error when subcommand is missing, got nil")
+	}
+}
+
+func TestCommandHelp(t *testing.T) {
+	p := writeConfig(t, `id: test
+vars:
+  url: ""
+flow:
+  actions:
+    - key: start
+      starting: true
+      steps:
+        - method: go
+          value: "{{url}}"
+        - method: body_includes
+          is_validator: true
+`)
+	if err := run([]string{"help", "--config", p}); err != nil {
+		t.Fatalf("help error: %v", err)
+	}
+}
+
+func TestCommandRun_EnvFile(t *testing.T) {
+	envPath := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(envPath, []byte("MY_VAR=hello\n# comment\n\nOTHER=world\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pairs, err := parseEnvFile(envPath)
+	if err != nil {
+		t.Fatalf("parseEnvFile error: %v", err)
+	}
+	if pairs["MY_VAR"] != "hello" {
+		t.Errorf("expected MY_VAR=hello, got %q", pairs["MY_VAR"])
+	}
+	if pairs["OTHER"] != "world" {
+		t.Errorf("expected OTHER=world, got %q", pairs["OTHER"])
 	}
 }
 

--- a/go-webminion/config/args.go
+++ b/go-webminion/config/args.go
@@ -1,0 +1,64 @@
+package config
+
+import "sort"
+
+var builtInVars = map[string]bool{
+	"flow_name": true, "today": true, "start_date": true, "end_date": true,
+}
+
+var credentialVars = map[string]bool{
+	"username": true, "password": true, "totp": true,
+}
+
+// RequiredArgs returns the placeholder names that must be supplied at runtime.
+// A placeholder is required when it is not a built-in, not a credential, and
+// is not already satisfied by a non-empty entry in config.Vars.
+func RequiredArgs(inst *Config) []string {
+	satisfied := make(map[string]bool)
+	for k, v := range inst.Vars {
+		if v != "" {
+			satisfied[k] = true
+		}
+	}
+
+	seen := make(map[string]bool)
+	for _, action := range inst.Flow.Actions {
+		for _, step := range action.Steps {
+			collectPlaceholders(step.Value, satisfied, seen)
+			collectPlaceholders(step.Pattern, satisfied, seen)
+			collectPlaceholders(step.Script, satisfied, seen)
+			if step.Target != nil {
+				collectSelectorPlaceholders(step.Target, satisfied, seen)
+			}
+			for i := range step.Targets {
+				collectSelectorPlaceholders(&step.Targets[i], satisfied, seen)
+			}
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func collectPlaceholders(s string, satisfied, seen map[string]bool) {
+	for _, match := range varPattern.FindAllStringSubmatch(s, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		name := match[1]
+		if builtInVars[name] || credentialVars[name] || satisfied[name] {
+			continue
+		}
+		seen[name] = true
+	}
+}
+
+func collectSelectorPlaceholders(sel *Selector, satisfied, seen map[string]bool) {
+	for _, field := range []string{sel.AriaLabel, sel.ID, sel.Name, sel.Text, sel.CSSPath} {
+		collectPlaceholders(field, satisfied, seen)
+	}
+}

--- a/go-webminion/config/args_test.go
+++ b/go-webminion/config/args_test.go
@@ -1,0 +1,99 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRequiredArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		inst *Config
+		want []string
+	}{
+		{
+			name: "no placeholders",
+			inst: &Config{
+				Flow: Flow{Actions: []Action{{
+					Key: "a", Starting: true,
+					Steps: []Step{{Method: "go", Value: "https://example.com", IsValidator: true}},
+				}}},
+			},
+			want: []string{},
+		},
+		{
+			name: "url placeholder with empty var declared",
+			inst: &Config{
+				Vars: map[string]string{"url": ""},
+				Flow: Flow{Actions: []Action{{
+					Key: "a", Starting: true,
+					Steps: []Step{{Method: "go", Value: "{{url}}", IsValidator: true}},
+				}}},
+			},
+			want: []string{"url"},
+		},
+		{
+			name: "satisfied by non-empty var",
+			inst: &Config{
+				Vars: map[string]string{"url": "https://example.com"},
+				Flow: Flow{Actions: []Action{{
+					Key: "a", Starting: true,
+					Steps: []Step{{Method: "go", Value: "{{url}}", IsValidator: true}},
+				}}},
+			},
+			want: []string{},
+		},
+		{
+			name: "built-ins and credentials excluded",
+			inst: &Config{
+				Flow: Flow{Actions: []Action{{
+					Key: "a", Starting: true,
+					Steps: []Step{{
+						Method:      "go",
+						Value:       "{{today}}/{{username}}",
+						IsValidator: true,
+					}},
+				}}},
+			},
+			want: []string{},
+		},
+		{
+			name: "multiple required args sorted",
+			inst: &Config{
+				Vars: map[string]string{"b": "", "a": ""},
+				Flow: Flow{Actions: []Action{{
+					Key: "a", Starting: true,
+					Steps: []Step{{Method: "go", Value: "{{b}}/{{a}}", IsValidator: true}},
+				}}},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "placeholder in selector",
+			inst: &Config{
+				Vars: map[string]string{"label": ""},
+				Flow: Flow{Actions: []Action{{
+					Key: "a", Starting: true,
+					Steps: []Step{{
+						Method:      "click",
+						Target:      &Selector{AriaLabel: "{{label}}"},
+						IsValidator: true,
+					}},
+				}}},
+			},
+			want: []string{"label"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RequiredArgs(tt.inst)
+			if got == nil {
+				got = []string{}
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RequiredArgs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/go-webminion/executor/executor.go
+++ b/go-webminion/executor/executor.go
@@ -26,12 +26,22 @@ type Executor struct {
 }
 
 // New creates an Executor. startDate and endDate are used for built-in interpolation vars.
-func New(cfg *config.Config, d driver.Driver, v vault.Vault, startDate, endDate time.Time) *Executor {
+// args supplies runtime values for placeholder variables; they override config.Vars defaults.
+func New(cfg *config.Config, d driver.Driver, v vault.Vault, startDate, endDate time.Time, args map[string]string) *Executor {
+	vars := interp.New(cfg.ID, startDate, endDate)
+	for k, val := range cfg.Vars {
+		if val != "" {
+			vars.Set(k, val) //nolint:errcheck
+		}
+	}
+	for k, val := range args {
+		vars.Set(k, val) //nolint:errcheck
+	}
 	return &Executor{
 		cfg:      cfg,
 		driver:   d,
 		vault:    v,
-		vars:     interp.New(cfg.ID, startDate, endDate),
+		vars:     vars,
 		registry: newStepRegistry(),
 		visited:  make(map[string]bool),
 	}

--- a/go-webminion/executor/executor_test.go
+++ b/go-webminion/executor/executor_test.go
@@ -57,7 +57,28 @@ func makeConfig(actions ...config.Action) *config.Config {
 }
 
 func newTestExecutor(cfg *config.Config, d driver.Driver) *Executor {
-	return New(cfg, d, nil, time.Now(), time.Now())
+	return New(cfg, d, nil, time.Now(), time.Now(), nil)
+}
+
+func TestExecutor_Run_PlaceholderArg(t *testing.T) {
+	fd := &fakeDriver{}
+	cfg := &config.Config{
+		ID:   "test",
+		Vars: map[string]string{"url": ""},
+		Flow: config.Flow{Actions: []config.Action{{
+			Key:      "start",
+			Starting: true,
+			Steps:    []config.Step{{Method: "go", Value: "{{url}}"}},
+		}}},
+	}
+
+	ex := New(cfg, fd, nil, time.Now(), time.Now(), map[string]string{"url": "https://example.com"})
+	if err := ex.Run(); err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if len(fd.navigated) != 1 || fd.navigated[0] != "https://example.com" {
+		t.Errorf("expected Navigate(https://example.com), got %v", fd.navigated)
+	}
 }
 
 func TestExecutor_Run_SingleAction(t *testing.T) {

--- a/go-webminion/webminion.go
+++ b/go-webminion/webminion.go
@@ -16,6 +16,7 @@ type Flow struct {
 	cfg       *config.Config
 	startDate time.Time
 	endDate   time.Time
+	args      map[string]string
 }
 
 // NewFlow loads and validates a YAML or JSON config file, returning a runnable Flow.
@@ -35,8 +36,21 @@ func (f *Flow) WithDateRange(start, end time.Time) *Flow {
 	return f
 }
 
+// WithArgs supplies runtime arguments for placeholder variables in the flow.
+// These override any empty-value entries in the config's vars map.
+func (f *Flow) WithArgs(args map[string]string) *Flow {
+	f.args = args
+	return f
+}
+
+// RequiredArgs returns the placeholder names that must be supplied via WithArgs
+// before calling Run. Built-ins, credentials, and vars with static defaults are excluded.
+func (f *Flow) RequiredArgs() []string {
+	return config.RequiredArgs(f.cfg)
+}
+
 // Run executes the automation flow using the provided driver and vault.
 func (f *Flow) Run(d driver.Driver, v vault.Vault) error {
-	ex := executor.New(f.cfg, d, v, f.startDate, f.endDate)
+	ex := executor.New(f.cfg, d, v, f.startDate, f.endDate, f.args)
 	return ex.Run()
 }


### PR DESCRIPTION
Add the ability for a flow to declare which runtime args it needs, expose them via an introspection API, and wire them through to the executor. Rewrite the CLI to use positional subcommands.

## Changes

**`config/args.go`** — new `RequiredArgs(inst)` function: scans all step fields for `{{placeholder}}` patterns and returns the names that are not built-ins (`flow_name`, `today`, etc.), not credentials (`username`, `password`, `totp`), and not already satisfied by a non-empty `config.Vars` entry.

**`webminion.go`** — `WithArgs(map[string]string) *Flow` and `RequiredArgs() []string` added to the public `Flow` API.

**`executor/executor.go`** — `New()` now seeds `interp.Vars` from static `config.Vars` (non-empty values) then overlays runtime args on top, so placeholder variables resolve correctly at execution time.

**`cmd/webminion/main.go`** — CLI switched from `--command=<cmd>` flag to positional subcommands:
- `wm run --config=f.yaml --arg url=https://... --env-file=.env`
- `wm validate --config=f.yaml`
- `wm help --config=f.yaml` — prints required args for the flow

**Flow config pattern** for a reusable parameterised flow:
```yaml
vars:
  url: ""   # empty = required at runtime
flow:
  actions:
    - key: start
      starting: true
      steps:
        - method: go
          value: "{{url}}"
```

```
$ wm help --config=navigate.yaml
Required args:
  url

$ wm run --config=navigate.yaml --arg url=https://example.com
```

## Test plan

- [ ] `go test ./...` passes (all packages green)
- [ ] `wm help --config=<flow with {{url}}>` prints `Required args:\n  url`
- [ ] `wm run --config=<same flow> --arg url=https://example.com` executes without error
- [ ] `wm run --config=<flow> --env-file=.env` loads vars from file; `--arg` overrides same key
- [ ] `wm validate --config=<valid flow>` prints `config is valid`
- [ ] `wm validate --config=<invalid flow>` returns a non-zero exit with error